### PR TITLE
Remove npm ci job from publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaanjah/prettier-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": ".prettierrc.json",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Project has no dependencies, so `npm ci` is not necessary.

Ref:
- https://github.com/JaanJah/prettier-config/actions/runs/13992779317/job/39180301207